### PR TITLE
Makefile dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-all:
-	./iongraph /tmp/ion.json
+all: /tmp/ion.json
+	./iongraph $<
 	./genpngs
 
 clean:


### PR DESCRIPTION
Have makefile target depend on /tmp/ion.json so dependencies are tracked properly.
