### PR TITLE
Bug 896783 - Make IonSpewer and IonGraph output the branch profiling data for each MBasicBlock.

### DIFF
--- a/iongraph
+++ b/iongraph
@@ -138,12 +138,11 @@ def getBlockLabel(b):
     s =  '<<table border="0" cellborder="0" cellpadding="1">'
 
     if 'blockUseCount' in b:
-        blockUseCount = str(b['blockUseCount'])
+        blockUseCount = "(Count: %s)" % str(b['blockUseCount'])
     else:
-        blockUseCount = 'N/A'
+        blockUseCount = ""
 
-    blockTitle = '<font color="white">Block %s (Count: %s)</font>' % \
-            (str(b['number']), blockUseCount)
+    blockTitle = '<font color="white">Block %s %s</font>' % (str(b['number']), blockUseCount)
     blockTitle = '<td align="center" bgcolor="black" colspan="3">%s</td>' % blockTitle
     s += '<tr>%s</tr>' % blockTitle
     


### PR DESCRIPTION
Hi sstangl,

Sorry for disturbing you. This patch let IonGraph show block counters for each MBasicBlock and LBlock. It won't break IonGraph when branch profiles are unavailable. 

More information is available at [bug 896783](https://bugzilla.mozilla.org/show_bug.cgi?id=896783) and [bug 877878](https://bugzilla.mozilla.org/show_bug.cgi?id=877878).
