### PR TITLE
Simplify PDF filenames.

### DIFF
--- a/genpdfs
+++ b/genpdfs
@@ -8,7 +8,7 @@ make_pdf_per_pass() {
 
 	# Otherwise, generate dot files sequentially.
 	ls -1 *.gv | while read g; do
-		dot "${g}" -Tpdf > "${g}.gv.pdf"
+		dot "${g}" -Tpdf > "${g}.pdf"
 	done
 }
 


### PR DESCRIPTION
Change "func*-pass*-*.gv.gv.pdf" to "func*-pass*-*.gv.pdf".