### PR TITLE
Bug 990106 - Add support for RecoveredOnBailout instructions.

### DIFF
--- a/iongraph
+++ b/iongraph
@@ -120,7 +120,9 @@ def getInstructionRow(inst):
     # Middle column: instruction name.
     instName = cgi.escape(inst['opcode'])
     if 'attributes' in inst:
-        if 'Movable' in inst['attributes']:
+        if 'RecoveredOnBailout' in inst['attributes']:
+            instName = '<font color="gray50">%s</font>' % instName
+        elif 'Movable' in inst['attributes']:
             instName = '<font color="blue">%s</font>' % instName
         if 'NeverHoisted' in inst['attributes']:
             instName = '<u>%s</u>' % instName


### PR DESCRIPTION
These patches are made to:
 1/ Highlight in red when a phase forgot to remove the InWorklist flag.
 2/ Shade in gray (like resume points) when an instruction is only executed on bailout paths.
